### PR TITLE
Added functionality: run entirely out of the directory in which pad.p…

### DIFF
--- a/binding.py
+++ b/binding.py
@@ -64,10 +64,10 @@ class Binding():
 
 
 class FileBinding(Binding):
-    __save_dir = None
-    __open_dir = None
+    __ctrl = None
     __toc = {}
     def __init__(self,ctrl):       # an ExternalConfiguration is still required because I may want to use encoding options, etc, as the project grows
+        self.__ctrl = ctrl
         src = ctrl["loc"]
         if src is None:
             p = pathlib.Path(".")
@@ -204,7 +204,8 @@ class FileBinding(Binding):
         
     def populate(self):
         self.__toc = {}
-        self.__delve(pathlib.Path(self._src) )
+        for directory in self.__ctrl["db"]["scan"]:
+            self.__delve(pathlib.Path(directory) )
 
     def clear(self):
         pass
@@ -218,22 +219,31 @@ class FileBinding(Binding):
         return ret_list
 
     def get_active_open(self):
-        return self.__open_dir
+        if "open" in self.__ctrl.keys():
+            return self.__ctrl["open"]
+        else:
+            return self.__ctrl["loc"]
 
     def set_active_open(self,d):
-        self.__open_dir = d
+        self.__ctrl["open"] = d
 
     def get_active_save(self):
-        return self.__save_dir
+        if "save" in self.__ctrl.keys():
+            return self.__ctrl["save"]
+        else:
+            return self.__ctrl["loc"]
 
     def set_active_save(self,d):
-        self.__save_dir = d
-        
+        self.__ctrl["save"] = d
+
     def get_active_base(self):
         return self._src
 
     def set_active_base(self,d):
         self.set_source(d)
+        self.__ctrl["loc"] = d
+
+
 
     
 
@@ -251,15 +261,12 @@ class DatabaseBinding(Binding):
     __db_name = None
     __scan_list = None
     __base_dir = None
-    __open_dir = None
-    __save_dir = None
     __ctrl = None
     __cursor = None
     
     def __init__(self,ctrl):
         self.__ctrl = ctrl
-        self.__save_dir = self.__open_dir = self.__base_dir = ctrl["loc"]
-        self.__db_name = ctrl["db"]["src"]
+        self.__db_name = str(ctrl["loc"]+os.sep+ctrl["db"]["src"])
         try:
             self._src = sqlite3.connect(self.__db_name)
         except Exception as e:
@@ -376,22 +383,28 @@ class DatabaseBinding(Binding):
                 self.__cursor.execute('''delete from bookmarks where ?=?''',parameters)
 
     def get_active_open(self):
-        return self.__open_dir
+        if "open" in self.__ctrl.keys():
+            return self.__ctrl["open"]
+        else:
+            return self.__ctrl["loc"]
 
     def set_active_open(self,d):
-        self.__open_dir = d
+        self.__ctrl["open"] = d
 
     def get_active_save(self):
-        return self.__save_dir
+        if "save" in self.__ctrl.keys():
+            return self.__ctrl["save"]
+        else:
+            return self.__ctrl["loc"]
 
     def set_active_save(self,d):
-        self.__save_dir = d
+        self.__ctrl["save"] = d
 
     def get_active_base(self):
-        return self.__base_dir
+        return self.__ctrl["loc"]
 
     def set_active_base(self,d):
-        self.__base_dir = d
+        self.__ctrl["loc"] = d
             
     def open_note(self,nl=[]):
         ### retrieve a note from source ###

--- a/conf.xml
+++ b/conf.xml
@@ -1,11 +1,14 @@
-<?xml version="1.0" ?><configuration>  
-    <loc>/home/travertine/help</loc>  
-      
-    <db>    
-      <src>memotest1.db</src>    
+<?xml version="1.0" ?>
+  <configuration>
+    <db>
+      <src>memotest1.db</src>
       <table>bookmarks</table>
-      <scan>/home/travertine/code/memobook/data</scan><scan>/home/travertine/help/python</scan><scan>/home/travertine/note</scan></db>
-    <suff>.txt</suff>  
-    
-    
-  <wrap>word</wrap><x>808</x><y>296</y></configuration>
+    </db>
+    <suff>.txt</suff>
+    <wrap>word</wrap>
+    <open>/home/travertine/help/dos</open>
+    <save>/home/travertine/help/audiovideo</save>
+    <loc>/home/travertine/code/memobook</loc>
+    <x>700</x>
+    <y>357</y>
+  </configuration>

--- a/memobook.py
+++ b/memobook.py
@@ -41,6 +41,12 @@ class Memobook:
             except Exception as e:
                 print("Error loading or preparing memobook: " + str(e))
                 return
+            else:
+                working_loc = str(os.path.dirname(kwargs["ctrl"]))
+                if working_loc == '':
+                    self.ctrl["loc"] = '.'
+                else:
+                    self.ctrl["loc"] = working_loc
         if "data" in kwargs.keys():
             self.data = kwargs["data"]
         else:
@@ -138,9 +144,9 @@ class Memobook:
             file_names = filedialog.askopenfilenames(initialdir=active_dir,title="Choose file(s) to open")
         if file_names:
             self.data.set_active_open(os.path.dirname(file_names[0]))
-        list_of_notes = self.data.open_note(file_names)
-        for nt in list_of_notes:
-            self.tabs.newpage(nt)
+            list_of_notes = self.data.open_note(file_names)
+            for nt in list_of_notes:
+                self.tabs.newpage(nt)
 
 
     def __save_note( self ):
@@ -270,7 +276,7 @@ class Memobook:
                 self.__close_page()
         self.ctrl["x"] = str(self.root.winfo_width()-self.offset[0])
         self.ctrl["y"] = str(self.root.winfo_height()-self.offset[1] - 19)
-        self.ctrl.print_config("conf.xml")
+        self.ctrl.print_config(str(self.ctrl["loc"]+os.sep+"conf.xml"))
         self.root.destroy()    
 
 


### PR DESCRIPTION
…y resides, rather than the pwd. This precipitated the following:

- changes to binding.py so that ctrl["loc"] is prepended to various paths
- alteration of get/set_active_save/open/base methods to access the external configuration, thereby allowing memobook to remember directories used for saving & opening.
- correction made to open_note routine in memobook.py for "cancel"
- alteration of FileBinding to reflect the functionality of DatabaseBinding